### PR TITLE
more tests and fixes: not supporting launching resolve for now, when …

### DIFF
--- a/pydavinci/utils.py
+++ b/pydavinci/utils.py
@@ -25,6 +25,13 @@ default_resolve_install = {
 }
 
 
+def is_resolve_obj(obj):
+    if type(obj) == type(pydavinci.main.resolve_obj):
+        return obj
+    else:
+        return False
+
+
 def get_proc_pid(name):
     for proc in psutil.process_iter():
         try:

--- a/pydavinci/wrappers/folder.py
+++ b/pydavinci/wrappers/folder.py
@@ -1,12 +1,22 @@
 from typing import TYPE_CHECKING, List
 
+from pydavinci.main import resolve_obj
+from pydavinci.utils import is_resolve_obj
+from pydavinci.pyremoteobject import PyRemoteObject
+
 if TYPE_CHECKING:
     from pydavinci.wrappers.mediapoolitem import MediaPoolItem
 
 
 class Folder(object):
-    def __init__(self, obj) -> None:
-        self._obj = obj
+    def __init__(self, *args) -> None:
+        if args:
+            if is_resolve_obj(args[0]):
+                self._obj = args[0]
+            else:
+                raise TypeError(f"{type(args[0])} is not a valid {self.__class__.__name__} type")
+        else:
+            raise TypeError(f"You need to provide at least one Resolve object.")
 
     @property
     def clips(self) -> List["MediaPoolItem"]:
@@ -24,4 +34,4 @@ class Folder(object):
         return self._obj.GetSubFolderList()
 
     def __repr__(self) -> str:
-        return f'Folder(Name:"{self.name}"'
+        return f'Folder(Name:"{self.name})"'

--- a/pydavinci/wrappers/mediapool.py
+++ b/pydavinci/wrappers/mediapool.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from pydavinci.main import resolve_obj, get_resolve
 from pydavinci.utils import get_resolveobjs
@@ -11,7 +11,7 @@ from pydavinci.wrappers.timelineitem import TimelineItem
 class MediaPool(object):
     def __init__(self) -> None:
 
-        self._obj = get_resolve().GetProjectManager().GetCurrentProject().GetMediaPool()
+        self._obj = resolve_obj.GetProjectManager().GetCurrentProject().GetMediaPool()
 
     @property
     def root_folder(self) -> "Folder":
@@ -75,7 +75,7 @@ class MediaPool(object):
     def unlink_clips(self, clips: List["MediaPoolItem"]) -> bool:
         return self._obj.UnlinkClips(get_resolveobjs(clips))
 
-    def import_media(self, paths: List[str]) -> List["MediaPoolItem"]:
+    def import_media(self, paths: Union[str, List[str]]) -> List["MediaPoolItem"]:
         # / TODO: Implement image sequence using ImportMedia({ClipInfo})
 
         imported = self._obj.ImportMedia(paths)

--- a/pydavinci/wrappers/mediapoolitem.py
+++ b/pydavinci/wrappers/mediapoolitem.py
@@ -1,4 +1,6 @@
 from typing import Dict, List
+from pydavinci.main import resolve_obj
+from pydavinci.utils import is_resolve_obj
 
 
 class MediaPoolItem(object):
@@ -7,8 +9,14 @@ class MediaPoolItem(object):
     # Meed to mess around with a private dict that uses
     # the SetMetadata() when internal dict updates
 
-    def __init__(self, obj):
-        self._obj = obj
+    def __init__(self, *args) -> None:
+        if args:
+            if is_resolve_obj(args[0]):
+                self._obj = args[0]
+            else:
+                raise TypeError(f"{type(args[0])} is not a valid {self.__class__.__name__} type")
+        else:
+            raise TypeError(f"You need to provide at least one Resolve object.")
 
     @property
     def name(self) -> str:

--- a/pydavinci/wrappers/mediastorage.py
+++ b/pydavinci/wrappers/mediastorage.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, List, Union
 
 from pydavinci.main import get_resolve, resolve_obj
+from pydavinci.wrappers._basewrappers import BaseResolveWrapper
 
 if TYPE_CHECKING:
     from pydavinci.wrappers.mediapoolitem import MediaPoolItem
@@ -8,7 +9,7 @@ if TYPE_CHECKING:
 
 class MediaStorage(object):
     def __init__(self) -> None:
-        self._obj = get_resolve().GetMediaStorage()
+        self._obj = resolve_obj.GetMediaStorage()
 
     @property
     def mounted_volumes(self):

--- a/pydavinci/wrappers/project.py
+++ b/pydavinci/wrappers/project.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 from pydavinci.exceptions import ObjectNotFound
 from pydavinci.main import resolve_obj, get_resolve
+from pydavinci.utils import is_resolve_obj
 
 if TYPE_CHECKING:
     from pydavinci.wrappers.mediapool import MediaPool
@@ -18,11 +19,14 @@ class Project(object):
         _type_: Object class
     """
 
-    def __init__(self, prj=None) -> None:
-        if prj:
-            self._obj = prj
+    def __init__(self, *args) -> None:
+        if args:
+            if is_resolve_obj(args[0]):
+                self._obj = args[0]
+            else:
+                raise TypeError(f"{type(args[0])} is not a valid {self.__class__.__name__} type")
         else:
-            self._obj = get_resolve().GetProjectManager().GetCurrentProject()
+            self._obj = resolve_obj.GetProjectManager().GetCurrentProject()
 
     @property
     def mediapool(self) -> "MediaPool":
@@ -150,18 +154,15 @@ class Project(object):
         return self._obj.SetSetting(setting, value)
 
     def save(self) -> bool:
-        from pydavinci.wrappers.projectmanager import ProjectManager
 
-        return ProjectManager._obj.SaveProject()
+        return resolve_obj.GetProjectManager().SaveProject()
 
     ## note: after loading the first project, it's impossible
     ## to close a project and go back to the window with only
     ## the project manager showing.
     ## It defaults to a 'Untitled Project', and you can't close it
     def close(self) -> bool:
-        from pydavinci.wrappers.projectmanager import ProjectManager
-
-        return ProjectManager._obj.CloseProject(self._obj)
+        return resolve_obj.GetProjectManager().CloseProject(self._obj)
 
     def open_timeline(self, name: str) -> bool:
         from pydavinci.wrappers.timeline import Timeline

--- a/pydavinci/wrappers/projectmanager.py
+++ b/pydavinci/wrappers/projectmanager.py
@@ -1,75 +1,81 @@
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-from pydavinci.main import get_resolve, resolve_obj
 from pydavinci.wrappers.project import Project
+from pydavinci.wrappers._basewrappers import BaseResolveWrapper
+from pydavinci.main import get_resolve, resolve_obj
+
+if TYPE_CHECKING:
+    from pydavinci.wrappers.project import Project
+
+# import fusionscript as dvr_script
 
 
-class ProjectManager(object):
-    try:
-        _obj = resolve_obj.GetProjectManager()  # if using this one here, everything fails
-    except AttributeError:
-        _obj = get_resolve().GetProjectManager()  # if using this here, closing projects fail
+class ProjectManager(BaseResolveWrapper):
+    # try:
+    #     _obj = resolve_obj.GetProjectManager()  # if using this one here, everything fails
+    # except AttributeError:
+    #     _obj = get_resolve().GetProjectManager()  # if using this here, closing projects fail
 
     def __init__(self) -> None:
 
-        pass
+        self._obj = resolve_obj.GetProjectManager()
 
-    @property
-    def project(self) -> "Project":
-        return Project()
-
-    def create_project(self, project_name: str) -> Project:
-        created = ProjectManager._obj.CreateProject(project_name)
+    def create_project(self, project_name: str) -> "Project":
+        created = self._obj.CreateProject(project_name)
         return Project(created)
 
     def delete_project(self, project_name: str) -> bool:
         return self._obj.DeleteProject(project_name)
 
-    def load_project(self, project_name: str) -> Project:
-        return Project(ProjectManager._obj.LoadProject(project_name))
+    def load_project(self, project_name: str) -> "Project":
+        return Project(self._obj.LoadProject(project_name))
 
-    def create_folder(self, folder_name: str) -> bool:
-        return ProjectManager._obj.CreateFolder(folder_name)
+    def close_project(self, project: "Project") -> bool:
+        return self._obj.CloseProject(project)
+
+    def create_folder(self, folder_name: str):
+        return self._obj.CreateFolder(folder_name)
 
     def delete_folder(self, folder_name: str) -> bool:
-        return ProjectManager._obj.DeleteFolder(folder_name)
+        return self._obj.DeleteFolder(folder_name)
 
     def project_list(self) -> List[str]:
-        return ProjectManager._obj.GetProjectListInCurrentFolder()
+        return self._obj.GetProjectListInCurrentFolder()
 
     def folder_list(self) -> List[str]:
-        return ProjectManager._obj.GetFolderListInCurrentFolder()
+        return self._obj.GetFolderListInCurrentFolder()
 
     def goto_root_folder(self) -> bool:
-        return ProjectManager._obj.GotoRootFolder()
+        return self._obj.GotoRootFolder()
 
     def goto_parent_folder(self) -> bool:
-        return ProjectManager._obj.GotoParentFolder()
+        return self._obj.GotoParentFolder()
 
     @property
     def folder(self) -> str:
-        return ProjectManager._obj.GetCurrentFolder()
+        return self._obj.GetCurrentFolder()
 
     def open_folder(self, folder_name: str) -> bool:
-        return ProjectManager._obj.OpenFolder(folder_name)
+        print("entru open folder")
+        return self._obj.OpenFolder(folder_name)
 
     def import_project(self, path: str) -> bool:
-        return ProjectManager._obj.ImportProject(path)
+        return self._obj.ImportProject(path)
 
     def export_project(self, project_name: str, path: str, stills_and_luts: bool = True) -> bool:
-        return ProjectManager._obj.ExportProject(project_name, path, stills_and_luts)
+        return self._obj.ExportProject(project_name, path, stills_and_luts)
 
     def restore_project(self, path: str) -> bool:
-        return ProjectManager._obj.RestoreProject(path)
+        return self._obj.RestoreProject(path)
 
     @property
     def db(self) -> dict:
-        return ProjectManager._obj.GetCurrentDatabase()
+        return self._obj.GetCurrentDatabase()
 
     @db.setter
     def db(self, db_info: dict) -> bool:
-        return ProjectManager._obj.SetCurrentDatabase(db_info)
+        return self._obj.SetCurrentDatabase(db_info)
 
     @property
     def db_list(self) -> List[Dict]:
-        return ProjectManager._obj.GetDatabaseList()
+        return self._obj.GetDatabaseList()

--- a/pydavinci/wrappers/resolve.py
+++ b/pydavinci/wrappers/resolve.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Optional
 
 import pydavinci.utils as utils
 from pydavinci.main import resolve_obj, get_resolve
+from pydavinci.wrappers._basewrappers import BaseResolveWrapper
+from pydavinci.utils import process_active
 
 if TYPE_CHECKING:
     from pydavinci.wrappers.mediapool import MediaPool
@@ -10,14 +12,17 @@ if TYPE_CHECKING:
     from pydavinci.wrappers.projectmanager import ProjectManager
 
 
-class Resolve(object):
+class Resolve(BaseResolveWrapper):
     def __init__(self, headless: Optional[bool] = None, path: Optional[str] = None):
 
-        if utils.launch_resolve(headless, path):
-            print("rolou")
+        # if utils.launch_resolve(headless, path): # this check is slow AF, to be implemented when we have auto-launch resolve
+        if not process_active("resolve"):
+            raise NotImplementedError(
+                "Couldn't find Davinci Resolve. Please make sure it's running"
+            )
 
         self.pages = ["media", "cut", "edit", "fusion", "color", "fairlight", "deliver"]
-        self._obj = get_resolve()
+        self._obj = resolve_obj
 
     @property
     def project_manager(self) -> "ProjectManager":
@@ -45,7 +50,7 @@ class Resolve(object):
 
     @property
     def fusion(self):
-        return get_resolve().Fusion()
+        return resolve_obj.Fusion()
 
     @property
     def page(self) -> str:
@@ -92,7 +97,7 @@ class Resolve(object):
     def active_timeline(self):
         from pydavinci.wrappers.timeline import Timeline
 
-        return Timeline(get_resolve().GetProjectManager().GetCurrentTimeline())
+        return Timeline()
 
     def __repr__(self) -> str:
         return f'Resolve(Page: "{self.page}")'

--- a/pydavinci/wrappers/timeline.py
+++ b/pydavinci/wrappers/timeline.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from pydavinci.utils import TRACK_ERROR, TRACK_TYPES, get_resolveobjs
+from pydavinci.utils import TRACK_ERROR, TRACK_TYPES, get_resolveobjs, is_resolve_obj
 from pydavinci.main import get_resolve, resolve_obj
 
 
@@ -10,11 +10,15 @@ if TYPE_CHECKING:
 
 
 class Timeline(object):
-    def __init__(self, data=None) -> None:
-        if data:
-            self._obj = data
+    def __init__(self, *args) -> None:
+        if args:
+            if is_resolve_obj(args[0]):
+                self._obj = args[0]
+            else:
+                raise TypeError(f"{type(args[0])} is not a valid {self.__class__.__name__} type")
         else:
-            self._obj = get_resolve().GetProjectManager().GetCurrentProject().GetCurrentTimeline()
+            print(" aqui")
+            self._obj = resolve_obj.GetProjectManager().GetCurrentProject().GetCurrentTimeline()
 
     @property
     def name(self) -> str:
@@ -24,8 +28,8 @@ class Timeline(object):
     def name(self, name: str) -> bool:
         return self._obj.SetName(name)
 
-    def activate(self):
-        return get_resolve().GetProjectManager().GetCurrentProject().SetCurrentTimeline(self._obj)
+    def activate(self) -> bool:
+        return resolve_obj.GetProjectManager().GetCurrentProject().SetCurrentTimeline(self._obj)
 
     @property
     def start_frame(self) -> int:

--- a/pydavinci/wrappers/timelineitem.py
+++ b/pydavinci/wrappers/timelineitem.py
@@ -1,12 +1,20 @@
 from typing import TYPE_CHECKING, Dict, List
+from pydavinci.utils import is_resolve_obj
+
 
 if TYPE_CHECKING:
     from pydavinci.wrappers.mediapoolitem import MediaPoolItem
 
 
 class TimelineItem(object):
-    def __init__(self, obj):
-        self._obj = obj
+    def __init__(self, *args) -> None:
+        if args:
+            if is_resolve_obj(args[0]):
+                self._obj = args[0]
+            else:
+                raise TypeError(f"{type(args[0])} is not a valid {self.__class__.__name__} type")
+        else:
+            raise TypeError(f"You need to provide at least one Resolve object.")
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
More tests and fixes: not supporting automatically launching resolve for now. For now we just check if we have a Resolve(.exe) process and continue.

When methods need to execute outside their scope, we are using `resolve_obj` for now. It works because Davinci is already running and the object tree is not messed up when the script runs.
